### PR TITLE
error link fix

### DIFF
--- a/Support/goerrs.rb
+++ b/Support/goerrs.rb
@@ -14,7 +14,7 @@ module Go
 
   def Go::href(file, line)
     file = normalize_file(file)
-    link = "txmt://open?line=#{$line}"
+    link = "txmt://open?line=#{line}"
     link << "&url=file://#{e_url(file)}"  if file
     link
   end


### PR DESCRIPTION
fix links not working properly when html output is produced while compiling a project with errors
see AlanQuatermain/go-tmbundle#5
