### PR TITLE
Updated to work with TextMate 2.0

### DIFF
--- a/Support/bin/gobin
+++ b/Support/bin/gobin
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+. "$TM_SUPPORT_PATH/lib/bash_init.sh"
 
 . goarch
 

--- a/Support/bin/goversion
+++ b/Support/bin/goversion
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+. "$TM_SUPPORT_PATH/lib/bash_init.sh"
 
 require_cmd "$GC"
 

--- a/Support/gocomp
+++ b/Support/gocomp
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+. "$TM_SUPPORT_PATH/lib/bash_init.sh"
 
 . gobin
 . goversion

--- a/Support/gomake
+++ b/Support/gomake
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+. "$TM_SUPPORT_PATH/lib/bash_init.sh"
 
 . gobin
 . goroot

--- a/Support/gopack
+++ b/Support/gopack
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+. "$TM_SUPPORT_PATH/lib/bash_init.sh"
 
 . gobin
 . goversion

--- a/Support/gorun
+++ b/Support/gorun
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+. "$TM_SUPPORT_PATH/lib/bash_init.sh"
 
 . gobin
 . goversion

--- a/Support/gotest
+++ b/Support/gotest
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+. "$TM_SUPPORT_PATH/lib/bash_init.sh"
 
 . gobin
 . goversion


### PR DESCRIPTION
The rule is that only commands without shebang has implicit sourcing of this initialization file. However, the way it is implemented in TextMate 1.x is by setting BASH_ENV in the environment for the command being executed, so if this command later runs a bash script, the variable is still in effect.

2.0 changes this to the strict interpretation of the rule so we need to explicitly source the initialization file if we use any of the functions it declares.

This commit still provides compatibility with TextMate 1.x. Ideally we add the command requirements to the bundle items (requires 2.0).
