### PR TITLE
Updated README - git clone url bug

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -10,7 +10,7 @@ If you'd rather do things manually, or if you want to make changes to the reposi
 
     mkdir "~/Library/Application Support/Avian/Bundles"
     cd "~/Library/Application Support/Avian/Bundles"
-    git clone git://github.com/AlanQuatermain/Go.tmbundle.git
+    git clone git://github.com/AlanQuatermain/go-tmbundle.git
 
 === Features
 The bundle here implements a language syntax, some snippets, and some compile/format/documentation commands for the Go language (http://golang.org/). Much of the current infrastructure was created by Martin Kühl (http://github.com/mkhl), who is a significantly more seasoned TextMate bundle developer than I, and to whom I am eternally grateful.


### PR DESCRIPTION
Seems like: git clone git://github.com/AlanQuatermain/Go.tmbundle.git
Should be git clone git://github.com/AlanQuatermain/go-tmbundle.git

$ git clone git://github.com/AlanQuatermain/Go.tmbundle.git
Cloning into 'Go.tmbundle'...
fatal: remote error: 
  Repository not found.
