### PR TITLE
Make “Go → Test” run tests for current file and other minor changes

### DIFF
--- a/Commands/Compile.tmCommand
+++ b/Commands/Compile.tmCommand
@@ -17,7 +17,7 @@ Go::go "build", :verb =&gt; "Compiling"
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
-	<string>@k</string>
+	<string>@b</string>
 	<key>name</key>
 	<string>Compile</string>
 	<key>outputCaret</key>

--- a/Commands/Test.tmCommand
+++ b/Commands/Test.tmCommand
@@ -17,9 +17,9 @@ Go::go "test", :verb =&gt; "Testing"
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
-	<string>~@t</string>
+	<string>@R</string>
 	<key>name</key>
-	<string>Test</string>
+	<string>Run Tests</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>

--- a/Support/gomate.rb
+++ b/Support/gomate.rb
@@ -20,12 +20,19 @@ module Go
     TextMate::Executor.make_project_master_current_document
 
     args = options[:args] ? options[:args] : []
-    opts = {:interactive_input => false, :use_hashbang => false, :version_args => ['version'], :version_regex => /\Ago version (.*)/}
+    opts = {:use_hashbang => false, :version_args => ['version'], :version_regex => /\Ago version (.*)/}
     opts[:verb] = options[:verb] if options[:verb]
 
-    # At this time, we will always run 'go' against a single file.  In the future there may be new
-    # commands that will invalidate this but until then, might as well start simple.
-    args.push(ENV['TM_FILEPATH'])
+    if command == 'test' && ENV['TM_FILENAME'] =~ /(_test)?(\.go)$/
+      basename = $`
+      args.push("#{basename}.go")
+      args.push("#{basename}_test.go")
+      opts[:chdir] = ENV['TM_DIRECTORY']
+    else
+      # At this time, we will always run 'go' against a single file.  In the future there may be new
+      # commands that will invalidate this but until then, might as well start simple.
+      args.push(ENV['TM_FILEPATH'])
+    end
     args.push(opts)
 
     TextMate::Executor.run(go_cmd, command, *args) do |str, type|

--- a/Support/gomate.rb
+++ b/Support/gomate.rb
@@ -35,9 +35,7 @@ module Go
     end
     args.push(opts)
 
-    TextMate::Executor.run(go_cmd, command, *args) do |str, type|
-      Go::link_errs(str, type)
-    end
+    TextMate::Executor.run(go_cmd, command, *args)
   end
 
   def Go::godoc

--- a/info.plist
+++ b/info.plist
@@ -17,9 +17,8 @@
 		<key>items</key>
 		<array>
 			<string>0B3C3EB0-9F51-4997-A87D-ECA507D8E31E</string>
-			<string>73628139-0077-4F09-9B72-77546D7C2D2D</string>
 			<string>0F6A8710-54FC-48F5-9D02-D093DA001D17</string>
-			<string>20810F68-79E2-4D36-B222-6374BDEAB7B9</string>
+			<string>73628139-0077-4F09-9B72-77546D7C2D2D</string>
 			<string>------------------------------------</string>
 			<string>7BCFCFC8-9152-4638-8436-E17B0C754C8D</string>
 			<string>B0271A46-F6EF-4D2F-95A6-EC067E69155C</string>


### PR DESCRIPTION
I don’t know under what circumstances the test runner previously worked, it may have been written for an oder version of the `go` tool.
