### PR TITLE
Changed Complete.tmCommand to accept TM_GOCODE path with spaces.

### DIFF
--- a/Commands/Complete.tmCommand
+++ b/Commands/Complete.tmCommand
@@ -20,7 +20,7 @@ end
 
 # byte offset of cursor position from the beginning of file
 cursor = document[ 0, ENV['TM_LINE_NUMBER'].to_i - 1].join().length + ENV['TM_LINE_INDEX'].to_i
-output = `$TM_GOCODE -f=csv -in=#{e_sh ENV['TM_FILEPATH']} autocomplete #{cursor}`
+output = `"$TM_GOCODE" -f=csv -in=#{e_sh ENV['TM_FILEPATH']} autocomplete #{cursor}`
 
 # quit if no completions found
 TextMate.exit_show_tool_tip("No completions found.") if output.length == 0


### PR DESCRIPTION
The breaking scenario is when user puts gocode exec file to Support Bundle in  ~/Library/Application Support/Textmate/{etc. etc.}.

Hitting Option+Esc results in pop-up: "sh: /Users/YOUR_USER/Library/Application: No such file or directory. No completions found".

This simple commit fixes that.
