### PR TITLE
Use version 1.8 of ruby for bundle items

### DIFF
--- a/Commands/Compile.tmCommand
+++ b/Commands/Compile.tmCommand
@@ -7,7 +7,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
 Go::go "build", :verb =&gt; "Compiling"

--- a/Commands/Complete.tmCommand
+++ b/Commands/Complete.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveActiveFile</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby -Ku
+	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -Ku
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui.rb'
 require ENV['TM_SUPPORT_PATH'] + "/lib/escape.rb"
 require ENV['TM_SUPPORT_PATH'] + "/lib/tm/require_cmd.rb"

--- a/Commands/Documentation for Word : Selection.tmCommand
+++ b/Commands/Documentation for Word : Selection.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
 Go::godoc

--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
 Go::gofmt

--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -7,7 +7,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
 Go::go "run", :verb =&gt; "Running"

--- a/Commands/Test.tmCommand
+++ b/Commands/Test.tmCommand
@@ -7,7 +7,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
 Go::go "test", :verb =&gt; "Testing"

--- a/Support/gomate.rb
+++ b/Support/gomate.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby
 
 require "#{ENV['TM_SUPPORT_PATH']}/lib/escape"
 require "#{ENV['TM_SUPPORT_PATH']}/lib/exit_codes"


### PR DESCRIPTION
10.7 and 10.8 only include ruby 1.8, so all bundle items have been written to work with that. Optionally supporting ruby 1.9 and 2.0 is problematic as these versions are not fully backwards compatible.

Fixes #43.
