### PR TITLE
Interface snippet should not conflict with the keyword `int`.

### DIFF
--- a/Snippets/Interface.tmSnippet
+++ b/Snippets/Interface.tmSnippet
@@ -11,7 +11,7 @@
 	<key>scope</key>
 	<string>source.go</string>
 	<key>tabTrigger</key>
-	<string>int</string>
+	<string>inte</string>
 	<key>uuid</key>
 	<string>96C65CC5-19C3-4B73-A66B-F9C80B98DE54</string>
 </dict>


### PR DESCRIPTION
When using the function snippet and declaring variables of type `int`, the Interface snippet conflicts and interrupts the current snippet:

```
func<tab>

func foo(x int<tab>) type {
  // body
}
```

Causes the interface snippet to kick in.
