### PR TITLE
Remove deprecated golang args

### DIFF
--- a/Support/gomate.rb
+++ b/Support/gomate.rb
@@ -77,12 +77,6 @@ module Go
 
     args = []
     args.push(gofmt_cmd)
-    args.push("-tabwidth=#{ENV['TM_TAB_SIZE']}")
-    if ENV['TM_SOFT_TABS'] && ENV['TM_SOFT_TABS'] == 'YES'
-      args.push('-tabs=false')
-    else
-      args.push('-tabs=true')
-    end
     args.push(ENV['TM_FILEPATH'])
 
     out, err = TextMate::Process.run(*args)


### PR DESCRIPTION
If you try to autoformat a file and you're using golang 1.3.3, you get this exception:

`flag provided but not defined: -tabwidth`

This issue describes that tabwidth and tabs are now removed from gofmt: https://code.google.com/p/go/issues/detail?id=7101
