### PR TITLE
Add support for the new %w format specifier

### DIFF
--- a/Syntaxes/Go.tmLanguage
+++ b/Syntaxes/Go.tmLanguage
@@ -766,7 +766,7 @@
                         [,;:_]?                                     # separator character (AltiVec)
                         ((-?\d+)|\*(-?\d+\$)?)?                     # minimum field width
                         (\.((-?\d+)|\*(-?\d+\$)?)?)?                # precision
-                        [diouxXDOUeEfFgGaAcCsSpnvtTbyYhHmMzZq%]      # conversion type
+                        [diouxXDOUeEfFgGaAcCsSpnvtTbyYhHmMzZqw%]    # conversion type
                     </string>
 					<key>name</key>
 					<string>constant.other.placeholder.go</string>


### PR DESCRIPTION
See: https://golang.org/pkg/fmt/#Errorf
```go
package main

import (
	"fmt"
	"io"
)

func main() {
	err := fmt.Errorf("error: %w", io.EOF)
	fmt.Println(err)

}
```