### PR TITLE
Support most of the new number literal proposal

### DIFF
--- a/Syntaxes/Go.tmLanguage
+++ b/Syntaxes/Go.tmLanguage
@@ -513,7 +513,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\.?[0-9]*)|(\.[0-9]+))((e|E)(\+|-)?[0-9]+)?)\b</string>
+					<string>(\b|\.)((0(x|X)[0-9a-fA-F_]*)|(0(o|O)[0-7_]*)|(0(b|B)[01_]*)|(([0-9_]+\.?[0-9_]*)|([0-9_]*\.?[0-9_]+))((e|E)(\+|-)?[0-9_]*)?i?)</string>
 					<key>name</key>
 					<string>constant.numeric.go</string>
 				</dict>


### PR DESCRIPTION
See: https://golang.org/doc/go1.13#language

https://regexr.com/4kq8m
vs
https://regexr.com/4kq92

I have never worked with TextMate before and I don't see any tests so I only tested my new regexp using the regexr.com above!

This doesn't support the new mantissa of a floating-point number in hexadecimal notation as that would make the regexp a lot bigger.